### PR TITLE
Call "enable" to prevent editor from turning gray

### DIFF
--- a/Source/NetworkEventsEditor.cpp
+++ b/Source/NetworkEventsEditor.cpp
@@ -50,6 +50,8 @@ NetworkEventsEditor::NetworkEventsEditor(GenericProcessor* parentNode, bool useD
     labelPort->setEditable(true);
     labelPort->addListener(this);
     addAndMakeVisible(labelPort);
+
+    enable();
 }
 
 


### PR DESCRIPTION
We originally removed the call to `setEnabledState` to prevent crashes when using this plugin with the latest version of the GUI. However, this results in a grayed-out editor, even though the functionality is intact.

Calling `enable` when initializing the plugin editor seems to fix this problem.